### PR TITLE
Add angular material autocomplete #25.

### DIFF
--- a/src/app/angular-material.module.ts
+++ b/src/app/angular-material.module.ts
@@ -37,6 +37,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTableModule } from '@angular/material/table';
 import { MatSortModule } from '@angular/material/sort';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { ReactiveFormsModule } from '@angular/forms';
 
 const MaterialModules = [
   MatButtonModule,
@@ -53,7 +55,9 @@ const MaterialModules = [
   MatTooltipModule,
   MatTableModule,
   MatSortModule,
-  MatSnackBarModule
+  MatSnackBarModule,
+  MatAutocompleteModule,
+  ReactiveFormsModule
 ];
 
 @NgModule({

--- a/src/app/hero-search/hero-search.component.html
+++ b/src/app/hero-search/hero-search.component.html
@@ -1,18 +1,16 @@
 <mat-divider></mat-divider>
 
 <div class="search-component">
-    <mat-form-field appearance="fill" class="search-form-field-width">
+    <mat-form-field appearance="fill">
         <mat-label>Search</mat-label>
-        <input matInput id="search-box" #searchBox (input)="search(searchBox.value)" placeholder="Hero Search">
+        <input matInput id="search-box" #searchBox [formControl]="searchFormControl" [matAutocomplete]="auto"
+            placeholder="Hero Search">
         <mat-icon matSuffix>search</mat-icon>
         <mat-hint>Ex.: type "Bom" or "Dr."</mat-hint>
+        <mat-autocomplete #auto="matAutocomplete">
+            <mat-option *ngFor="let hero of filteredHeroes | async" [value]="hero.name" (click)="goToHeroDetail(hero)">
+                {{ hero.name }}
+            </mat-option>
+        </mat-autocomplete>
     </mat-form-field>
-
-    <ul class="search-result">
-        <li *ngFor="let hero of heroes$ | async">
-            <a routerLink="/detail/{{hero.id}}">
-                {{hero.name}}
-            </a>
-        </li>
-    </ul>
 </div>

--- a/src/app/hero-search/hero-search.component.scss
+++ b/src/app/hero-search/hero-search.component.scss
@@ -1,49 +1,6 @@
 /* HeroSearch private styles */
-$border: 1px solid gray;
-
-.search-result {
-  li {
-    border-bottom: $border;
-    border-left: $border;
-    border-right: $border;
-    width: 195px;
-    height: 16px;
-    padding: 5px;
-    background-color: white;
-    cursor: pointer;
-    list-style-type: none;
-
-    &:hover {
-      background-color: #607d8b;
-    }
-
-    a {
-      color: #888;
-      display: block;
-      text-decoration: none;
-
-      &:hover {
-        color: white;
-      }
-
-      &:active {
-        color: white;
-      }
-    }
-  }
-}
-
-ul {
-  &.search-result {
-    margin-top: 0;
-    padding-left: 0;
-  }
-}
-
 .search-component {
-  margin-top: 10px;
-}
-
-.search-form-field-width {
-  width: 25%;
+  margin: 10px;
+  padding: 10px;
+  width: 100%;
 }

--- a/src/app/hero-search/hero-search.component.ts
+++ b/src/app/hero-search/hero-search.component.ts
@@ -22,11 +22,13 @@
  * THE SOFTWARE.
  */
 import { Component, OnInit } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { FormControl } from '@angular/forms';
+import { Observable } from 'rxjs';
 
 import { Hero } from '../hero';
 import { HeroService } from '../hero.service';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { Router } from '@angular/router';
 
 
 @Component({
@@ -36,22 +38,28 @@ import { HeroService } from '../hero.service';
 })
 export class HeroSearchComponent implements OnInit {
 
-  heroes$: Observable<Hero[]>;
-  private searchTerms = new Subject<string>();
+  searchFormControl = new FormControl();
+  filteredHeroes: Observable<Hero[]>;
 
-  constructor(private heroService: HeroService) { }
+  constructor(
+    private heroService: HeroService,
+    private router: Router
+  ) { }
 
   ngOnInit() {
 
-    this.heroes$ = this.searchTerms.pipe(
-      debounceTime(300), // wait 300ms after each keystroke before considering the term
-      distinctUntilChanged(), // ignore new term if same as previous term
-      switchMap((term: string) => this.heroService.searchHeroes(term)) // switch to new search observable each time the term changes
-    );
+    this.filteredHeroes = this.searchFormControl.valueChanges
+      .pipe(
+        debounceTime(300), // wait 300ms after each keystroke before considering the term
+        distinctUntilChanged(), // ignore new term if same as previous term
+        switchMap((term: string) => this.heroService.searchHeroes(term)) // switch to new search observable each time the term changes
+      );
   }
 
-  // Push a search term into the observable stream.
-  search(term: string): void {
-    this.searchTerms.next(term);
+  goToHeroDetail(hero: Hero): void {
+
+    const url = `/detail/${hero.id}`;
+
+    this.router.navigateByUrl(url);
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR removes the patchwork autocomplete at [hero-search component](https://github.com/julianomacielferreira/tour-of-heroes/tree/material-design/src/app/hero-search) by replacing it with Angular Material autocomplete.

#### Where should the review begin?
Should start reading the code at [hero-search](https://github.com/julianomacielferreira/tour-of-heroes/tree/material-design/src/app/hero-search) component.

#### How could this be tested manually?

Run the app with ng serve --open and interact with the app.

#### Any context scenarios you want to give?

None. The functionality stayed the same.

### Screenshots

![2019-10-02-092652_1920x1080_scrot](https://user-images.githubusercontent.com/49996266/66043977-ecf3d000-e4f6-11e9-85ec-87f8b226bbcc.png)
![2019-10-02-092707_1920x1080_scrot](https://user-images.githubusercontent.com/49996266/66043978-ecf3d000-e4f6-11e9-87f8-df1ea749691a.png)


#### What are relevant tickets?
Fix #25 

### References
[https://material.angular.io/components/autocomplete/overview](https://material.angular.io/components/autocomplete/overview)